### PR TITLE
Introduce graceful transactions closing on drop

### DIFF
--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -41,7 +41,7 @@ use itertools::Itertools;
 use resource::profile::{CommitProfile, StorageCounters};
 use storage::{
     durability_client::WALClient,
-    snapshot::{CommittableSnapshot, ReadSnapshot, WritableSnapshot, WriteSnapshot},
+    snapshot::{CommittableSnapshot, ReadSnapshot, ReadableSnapshot, WritableSnapshot, WriteSnapshot},
 };
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;

--- a/database/query.rs
+++ b/database/query.rs
@@ -88,7 +88,7 @@ pub fn execute_write_query_in_schema(
     } = transaction;
 
     let (snapshot, result) = execute_write_query_in(
-        Arc::into_inner(snapshot).unwrap(),
+        snapshot.into_inner(),
         &type_manager,
         thing_manager.clone(),
         &function_manager,
@@ -132,7 +132,7 @@ pub fn execute_write_query_in_write(
     } = transaction;
 
     let (snapshot, result) = execute_write_query_in(
-        Arc::into_inner(snapshot).expect("Cannot unwrap Arc<Snapshot>, still in use."),
+        snapshot.into_inner(),
         &type_manager,
         thing_manager.clone(),
         &function_manager,

--- a/database/tests/transaction.rs
+++ b/database/tests/transaction.rs
@@ -145,6 +145,35 @@ fn open_close_read_transaction() {
 /////////////////////////////
 
 #[test]
+fn schema_transaction_does_not_block_concurrent_schema_transactions_after_freeing() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let _tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+                // it frees the locks here
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_schema = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap();
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
 fn schema_transaction_blocks_concurrent_schema_transactions() {
     init_logging();
     let databases_path = create_tmp_dir();
@@ -312,18 +341,22 @@ fn schema_transaction_rollback_does_not_unblock_concurrent_schema_transactions()
             let database_clone = database.clone();
             let notify_transaction1_ready = Arc::new(Notify::new());
             let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+            let notify_can_drop = Arc::new(Notify::new());
+            let notify_can_drop_clone = notify_can_drop.clone();
 
             let task1 = tokio::spawn(async move {
                 let mut tx_schema = open_schema(database);
                 notify_transaction1_ready.notify_one();
                 sleep(transaction_sleep_timeout()).await;
                 tx_schema.rollback();
+                notify_can_drop_clone.notified().await; // don't drop until done
             });
 
             let task2 = tokio::spawn(async move {
                 notify_transaction1_ready_clone.notified().await;
                 let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
                 assert_transaction_timeout!(error);
+                notify_can_drop.notify_one();
             });
 
             tokio::try_join!(task1, task2)
@@ -403,18 +436,22 @@ fn schema_transaction_rollback_does_not_unblock_concurrent_write_transactions() 
             let database_clone = database.clone();
             let notify_transaction1_ready = Arc::new(Notify::new());
             let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+            let notify_can_drop = Arc::new(Notify::new());
+            let notify_can_drop_clone = notify_can_drop.clone();
 
             let task1 = tokio::spawn(async move {
                 let mut tx_schema = open_schema(database);
                 notify_transaction1_ready.notify_one();
                 sleep(transaction_sleep_timeout()).await;
                 tx_schema.rollback();
+                notify_can_drop_clone.notified().await; // don't drop until done
             });
 
             let task2 = tokio::spawn(async move {
                 notify_transaction1_ready_clone.notified().await;
                 let error = TransactionWrite::open(database_clone, TransactionOptions::default()).unwrap_err();
                 assert_transaction_timeout!(error);
+                notify_can_drop.notify_one();
             });
 
             tokio::try_join!(task1, task2)
@@ -427,32 +464,65 @@ fn schema_transaction_rollback_does_not_unblock_concurrent_write_transactions() 
 /////////////////////////////
 
 #[test]
+fn write_transaction_does_not_block_concurrent_schema_transactions_after_freeing() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let _tx_write = open_write(database);
+                notify_transaction1_ready.notify_one();
+                // it frees the locks here
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_schema = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap();
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
 fn write_transaction_blocks_concurrent_schema_transactions() {
     init_logging();
     let databases_path = create_tmp_dir();
     let database = create_database(&databases_path);
 
     let runtime = Runtime::new().expect("Expected runtime");
-    runtime.block_on(async move {
-        let database_clone = database.clone();
-        let notify_transaction1_ready = Arc::new(Notify::new());
-        let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+            let notify_can_drop = Arc::new(Notify::new());
+            let notify_can_drop_clone = notify_can_drop.clone();
 
-        tokio::spawn(async move {
-            let _tx_write = open_write(database);
-            notify_transaction1_ready.notify_one();
-        })
-        .await
-        .unwrap();
+            let task1 = tokio::spawn(async move {
+                let _tx_write = open_write(database);
+                notify_transaction1_ready.notify_one();
+                notify_can_drop_clone.notified().await; // don't drop _tx_write until then
+            });
 
-        tokio::spawn(async move {
-            notify_transaction1_ready_clone.notified().await;
-            let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
-            assert_transaction_timeout!(error);
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
+                assert_transaction_timeout!(error);
+                notify_can_drop.notify_one();
+            });
+
+            tokio::try_join!(task1, task2)
         })
-        .await
         .unwrap();
-    });
 }
 
 #[test]
@@ -527,18 +597,22 @@ fn write_transaction_rollback_does_not_unblock_concurrent_schema_transactions() 
             let database_clone = database.clone();
             let notify_transaction1_ready = Arc::new(Notify::new());
             let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+            let notify_can_drop = Arc::new(Notify::new());
+            let notify_can_drop_clone = notify_can_drop.clone();
 
             let task1 = tokio::spawn(async move {
                 let mut tx_write = open_write(database);
                 notify_transaction1_ready.notify_one();
                 sleep(transaction_sleep_timeout()).await;
                 tx_write.rollback();
+                notify_can_drop_clone.notified().await; // don't drop until done
             });
 
             let task2 = tokio::spawn(async move {
                 notify_transaction1_ready_clone.notified().await;
                 let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
                 assert_transaction_timeout!(error);
+                notify_can_drop.notify_one();
             });
 
             tokio::try_join!(task1, task2)

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -3,8 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::{mpsc::RecvTimeoutError, Arc};
+use std::{
+    fmt::Formatter,
+    ops::Deref,
+    sync::{mpsc::RecvTimeoutError, Arc},
+};
 
 use concept::{
     error::ConceptWriteError,
@@ -37,7 +40,7 @@ pub struct TransactionRead<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: Arc<Database<D>>,
+    pub database: SyncDatabaseDropGuard<D>,
     transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -76,7 +79,7 @@ impl<D: DurabilityClient> TransactionRead<D> {
             thing_manager,
             function_manager,
             query_manager,
-            database,
+            database: DatabaseDropGuard::new(database),
             transaction_options,
             profile: TransactionProfile::new(tracing::enabled!(Level::TRACE)),
         })
@@ -87,9 +90,7 @@ impl<D: DurabilityClient> TransactionRead<D> {
     }
 
     pub fn close(self) {
-        // TODO: Should be done automatically
-        // drop(self.thing_manager);
-        // drop(self.type_manager);
+        drop(self)
     }
 }
 
@@ -100,7 +101,7 @@ pub struct TransactionWrite<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: Arc<Database<D>>,
+    pub database: SyncDatabaseDropGuard<D>,
     pub transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -134,7 +135,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
             thing_manager,
             function_manager,
             query_manager,
-            database,
+            database: DatabaseDropGuard::new_with_fn(database, Database::release_write_transaction),
             transaction_options,
             profile: TransactionProfile::new(tracing::enabled!(Level::TRACE)),
         })
@@ -146,7 +147,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
         query_manager: Arc<QueryManager>,
-        database: Arc<Database<D>>,
+        database: SyncDatabaseDropGuard<D>,
         transaction_options: TransactionOptions,
         profile: TransactionProfile,
     ) -> Self {
@@ -164,9 +165,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
 
     pub fn commit(mut self) -> (TransactionProfile, Result<(), DataCommitError>) {
         self.profile.commit_profile().start();
-        let database = self.database.clone();
         let (mut profile, result) = self.try_commit();
-        database.release_write_transaction();
         profile.commit_profile().end();
         (profile, result)
     }
@@ -197,7 +196,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     }
 
     pub fn close(self) {
-        self.database.release_write_transaction();
+        drop(self)
     }
 }
 
@@ -220,7 +219,7 @@ pub struct TransactionSchema<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: Arc<Database<D>>,
+    pub database: SyncDatabaseDropGuard<D>,
     pub transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -252,7 +251,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
             thing_manager: Arc::new(thing_manager),
             function_manager,
             query_manager,
-            database,
+            database: DatabaseDropGuard::new_with_fn(database, Database::release_schema_transaction),
             transaction_options,
             profile: TransactionProfile::new(tracing::enabled!(Level::TRACE)),
         })
@@ -264,7 +263,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
         query_manager: Arc<QueryManager>,
-        database: Arc<Database<D>>,
+        database: SyncDatabaseDropGuard<D>,
         transaction_options: TransactionOptions,
         profile: TransactionProfile,
     ) -> Self {
@@ -282,9 +281,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
 
     pub fn commit(mut self) -> (TransactionProfile, Result<(), SchemaCommitError>) {
         self.profile.commit_profile().start();
-        let database = self.database.clone(); // TODO: can we get away without cloning the database before?
         let (mut profile, result) = self.try_commit(); // TODO include
-        database.release_schema_transaction();
         profile.commit_profile().end();
         (profile, result)
     }
@@ -388,11 +385,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
     }
 
     pub fn close(self) {
-        // TODO: Should work by itself
-        self.database.release_schema_transaction();
-        // drop(self.thing_manager);
-        // drop(self.type_manager);
-        // Arc::into_inner(self.snapshot).unwrap().close_resources();
+        drop(self)
     }
 }
 
@@ -429,6 +422,51 @@ macro_rules! with_transaction_parts {
         ($transaction, result)
     }};
 }
+
+pub struct DatabaseDropGuard<D, F: FnOnce(&Database<D>)> {
+    database: Option<Arc<Database<D>>>,
+    on_drop_fn: Option<F>,
+}
+
+impl<D, F: FnOnce(&Database<D>)> DatabaseDropGuard<D, F> {
+    pub fn new(database: Arc<Database<D>>) -> Self {
+        Self { database: Some(database), on_drop_fn: None }
+    }
+
+    pub fn new_with_fn(database: Arc<Database<D>>, on_drop_fn: F) -> Self {
+        Self { database: Some(database), on_drop_fn: Some(on_drop_fn) }
+    }
+
+    fn database(&self) -> &Arc<Database<D>> {
+        self.database.as_ref().expect("Expected a database in the guard")
+    }
+}
+
+impl<D, F: FnOnce(&Database<D>)> Deref for DatabaseDropGuard<D, F> {
+    type Target = Arc<Database<D>>;
+
+    fn deref(&self) -> &Self::Target {
+        self.database()
+    }
+}
+
+impl<D, F: FnOnce(&Database<D>)> Drop for DatabaseDropGuard<D, F> {
+    fn drop(&mut self) {
+        println!("DROP ON GUARD!");
+        if let Some(on_drop_fn) = self.on_drop_fn.take() {
+            let database = self.database.take().expect("Expected database");
+            on_drop_fn(&database);
+        }
+    }
+}
+
+impl<D, F: FnOnce(&Database<D>)> std::fmt::Debug for DatabaseDropGuard<D, F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.database)
+    }
+}
+
+type SyncDatabaseDropGuard<D> = DatabaseDropGuard<D, fn(&Database<D>)>;
 
 // TODO: Same issue with ConceptWriteErrors vs ErrorsFirst as for DataCommitError
 typedb_error! {

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -192,7 +192,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     }
 
     pub fn rollback(&mut self) {
-        self.snapshot.clear()
+        self.snapshot.as_mut().expect("Expected owning snapshot on rollback").clear()
     }
 
     pub fn close(self) {
@@ -381,7 +381,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
     }
 
     pub fn rollback(&mut self) {
-        self.snapshot.clear()
+        self.snapshot.as_mut().expect("Expected owning snapshot on rollback").clear()
     }
 
     pub fn close(self) {

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -452,7 +452,6 @@ impl<D, F: FnOnce(&Database<D>)> Deref for DatabaseDropGuard<D, F> {
 
 impl<D, F: FnOnce(&Database<D>)> Drop for DatabaseDropGuard<D, F> {
     fn drop(&mut self) {
-        println!("DROP ON GUARD!");
         if let Some(on_drop_fn) = self.on_drop_fn.take() {
             let database = self.database.take().expect("Expected database");
             on_drop_fn(&database);

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -40,7 +40,7 @@ pub struct TransactionRead<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: SyncDatabaseDropGuard<D>,
+    pub database: FnDatabaseDropGuard<D>,
     transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -101,7 +101,7 @@ pub struct TransactionWrite<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: SyncDatabaseDropGuard<D>,
+    pub database: FnDatabaseDropGuard<D>,
     pub transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -147,7 +147,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
         query_manager: Arc<QueryManager>,
-        database: SyncDatabaseDropGuard<D>,
+        database: FnDatabaseDropGuard<D>,
         transaction_options: TransactionOptions,
         profile: TransactionProfile,
     ) -> Self {
@@ -219,7 +219,7 @@ pub struct TransactionSchema<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: SyncDatabaseDropGuard<D>,
+    pub database: FnDatabaseDropGuard<D>,
     pub transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -263,7 +263,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
         query_manager: Arc<QueryManager>,
-        database: SyncDatabaseDropGuard<D>,
+        database: FnDatabaseDropGuard<D>,
         transaction_options: TransactionOptions,
         profile: TransactionProfile,
     ) -> Self {
@@ -466,7 +466,7 @@ impl<D, F: FnOnce(&Database<D>)> std::fmt::Debug for DatabaseDropGuard<D, F> {
     }
 }
 
-type SyncDatabaseDropGuard<D> = DatabaseDropGuard<D, fn(&Database<D>)>;
+type FnDatabaseDropGuard<D> = DatabaseDropGuard<D, fn(&Database<D>)>;
 
 // TODO: Same issue with ConceptWriteErrors vs ErrorsFirst as for DataCommitError
 typedb_error! {

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -40,7 +40,7 @@ pub struct TransactionRead<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: FnDatabaseDropGuard<D>,
+    pub database: DatabaseDropGuard<D>,
     transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -101,7 +101,7 @@ pub struct TransactionWrite<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: FnDatabaseDropGuard<D>,
+    pub database: DatabaseDropGuard<D>,
     pub transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -147,7 +147,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
         query_manager: Arc<QueryManager>,
-        database: FnDatabaseDropGuard<D>,
+        database: DatabaseDropGuard<D>,
         transaction_options: TransactionOptions,
         profile: TransactionProfile,
     ) -> Self {
@@ -219,7 +219,7 @@ pub struct TransactionSchema<D> {
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
     pub query_manager: Arc<QueryManager>,
-    pub database: FnDatabaseDropGuard<D>,
+    pub database: DatabaseDropGuard<D>,
     pub transaction_options: TransactionOptions,
     pub profile: TransactionProfile,
 }
@@ -263,7 +263,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
         query_manager: Arc<QueryManager>,
-        database: FnDatabaseDropGuard<D>,
+        database: DatabaseDropGuard<D>,
         transaction_options: TransactionOptions,
         profile: TransactionProfile,
     ) -> Self {
@@ -404,7 +404,7 @@ macro_rules! with_transaction_parts {
             transaction_options,
             profile,
         } = $transaction;
-        let mut $inner_snapshot = Arc::into_inner(snapshot).unwrap();
+        let mut $inner_snapshot = snapshot.into_inner();
 
         let result = $expr;
 
@@ -423,17 +423,17 @@ macro_rules! with_transaction_parts {
     }};
 }
 
-pub struct DatabaseDropGuard<D, F: FnOnce(&Database<D>)> {
+pub struct DatabaseDropGuard<D> {
     database: Option<Arc<Database<D>>>,
-    on_drop_fn: Option<F>,
+    on_drop_fn: Option<fn(&Database<D>)>,
 }
 
-impl<D, F: FnOnce(&Database<D>)> DatabaseDropGuard<D, F> {
+impl<D> DatabaseDropGuard<D> {
     pub fn new(database: Arc<Database<D>>) -> Self {
         Self { database: Some(database), on_drop_fn: None }
     }
 
-    pub fn new_with_fn(database: Arc<Database<D>>, on_drop_fn: F) -> Self {
+    pub fn new_with_fn(database: Arc<Database<D>>, on_drop_fn: fn(&Database<D>)) -> Self {
         Self { database: Some(database), on_drop_fn: Some(on_drop_fn) }
     }
 
@@ -442,7 +442,7 @@ impl<D, F: FnOnce(&Database<D>)> DatabaseDropGuard<D, F> {
     }
 }
 
-impl<D, F: FnOnce(&Database<D>)> Deref for DatabaseDropGuard<D, F> {
+impl<D> Deref for DatabaseDropGuard<D> {
     type Target = Arc<Database<D>>;
 
     fn deref(&self) -> &Self::Target {
@@ -450,7 +450,7 @@ impl<D, F: FnOnce(&Database<D>)> Deref for DatabaseDropGuard<D, F> {
     }
 }
 
-impl<D, F: FnOnce(&Database<D>)> Drop for DatabaseDropGuard<D, F> {
+impl<D> Drop for DatabaseDropGuard<D> {
     fn drop(&mut self) {
         if let Some(on_drop_fn) = self.on_drop_fn.take() {
             let database = self.database.take().expect("Expected database");
@@ -459,13 +459,11 @@ impl<D, F: FnOnce(&Database<D>)> Drop for DatabaseDropGuard<D, F> {
     }
 }
 
-impl<D, F: FnOnce(&Database<D>)> std::fmt::Debug for DatabaseDropGuard<D, F> {
+impl<D> std::fmt::Debug for DatabaseDropGuard<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.database)
     }
 }
-
-type FnDatabaseDropGuard<D> = DatabaseDropGuard<D, fn(&Database<D>)>;
 
 // TODO: Same issue with ConceptWriteErrors vs ErrorsFirst as for DataCommitError
 typedb_error! {

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -21,7 +21,10 @@ use query::query_manager::QueryManager;
 use resource::profile::TransactionProfile;
 use storage::{
     durability_client::DurabilityClient,
-    snapshot::{CommittableSnapshot, ReadSnapshot, SchemaSnapshot, SnapshotError, WritableSnapshot, WriteSnapshot},
+    snapshot::{
+        CommittableSnapshot, ReadSnapshot, SchemaSnapshot, SnapshotDropGuard, SnapshotError, WritableSnapshot,
+        WriteSnapshot,
+    },
 };
 use tracing::Level;
 
@@ -29,7 +32,7 @@ use crate::Database;
 
 #[derive(Debug)]
 pub struct TransactionRead<D> {
-    pub snapshot: Arc<ReadSnapshot<D>>,
+    pub snapshot: SnapshotDropGuard<ReadSnapshot<D>>,
     pub type_manager: Arc<TypeManager>,
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
@@ -68,7 +71,7 @@ impl<D: DurabilityClient> TransactionRead<D> {
         drop(schema);
 
         Ok(Self {
-            snapshot: Arc::new(snapshot),
+            snapshot: SnapshotDropGuard::new(snapshot),
             type_manager,
             thing_manager,
             function_manager,
@@ -84,15 +87,15 @@ impl<D: DurabilityClient> TransactionRead<D> {
     }
 
     pub fn close(self) {
-        drop(self.thing_manager);
-        drop(self.type_manager);
-        Arc::into_inner(self.snapshot).unwrap().close_resources()
+        // TODO: Should be done automatically
+        // drop(self.thing_manager);
+        // drop(self.type_manager);
     }
 }
 
 #[derive(Debug)]
 pub struct TransactionWrite<D> {
-    pub snapshot: Arc<WriteSnapshot<D>>,
+    pub snapshot: SnapshotDropGuard<WriteSnapshot<D>>,
     pub type_manager: Arc<TypeManager>,
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
@@ -126,7 +129,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
         drop(schema);
 
         Ok(Self {
-            snapshot: Arc::new(snapshot),
+            snapshot: SnapshotDropGuard::new(snapshot),
             type_manager,
             thing_manager,
             function_manager,
@@ -148,7 +151,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
         profile: TransactionProfile,
     ) -> Self {
         Self {
-            snapshot,
+            snapshot: SnapshotDropGuard::from_arc(snapshot),
             type_manager,
             thing_manager,
             function_manager,
@@ -171,7 +174,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     pub fn try_commit(self) -> (TransactionProfile, Result<(), DataCommitError>) {
         let mut profile = self.profile;
         let commit_profile = profile.commit_profile();
-        let mut snapshot = match Arc::into_inner(self.snapshot) {
+        let mut snapshot = match self.snapshot.try_into_inner() {
             None => return (profile, Err(DataCommitError::SnapshotInUse {})),
             Some(snapshot) => snapshot,
         };
@@ -190,14 +193,11 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     }
 
     pub fn rollback(&mut self) {
-        Arc::get_mut(&mut self.snapshot).unwrap().clear()
+        self.snapshot.clear()
     }
 
     pub fn close(self) {
         self.database.release_write_transaction();
-        drop(self.thing_manager);
-        drop(self.type_manager);
-        Arc::into_inner(self.snapshot).unwrap().close_resources()
     }
 }
 
@@ -215,7 +215,7 @@ typedb_error! {
 
 #[derive(Debug)]
 pub struct TransactionSchema<D> {
-    pub snapshot: Arc<SchemaSnapshot<D>>,
+    pub snapshot: SnapshotDropGuard<SchemaSnapshot<D>>,
     pub type_manager: Arc<TypeManager>,
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
@@ -247,7 +247,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         let query_manager = Arc::new(QueryManager::new(None));
 
         Ok(Self {
-            snapshot: Arc::new(snapshot),
+            snapshot: SnapshotDropGuard::new(snapshot),
             type_manager,
             thing_manager: Arc::new(thing_manager),
             function_manager,
@@ -269,7 +269,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         profile: TransactionProfile,
     ) -> Self {
         Self {
-            snapshot,
+            snapshot: SnapshotDropGuard::from_arc(snapshot),
             type_manager,
             thing_manager,
             function_manager,
@@ -295,7 +295,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         };
         let mut profile = self.profile;
         let commit_profile = profile.commit_profile();
-        let mut snapshot = Arc::into_inner(self.snapshot).expect("Failed to unwrap Arc<Snapshot>");
+        let mut snapshot = self.snapshot.into_inner();
         if let Err(errs) = self.type_manager.validate(&snapshot) {
             // TODO: send all the errors, not just the first,
             // when we can print the stacktraces of multiple errors, not just a single one
@@ -384,14 +384,15 @@ impl<D: DurabilityClient> TransactionSchema<D> {
     }
 
     pub fn rollback(&mut self) {
-        Arc::get_mut(&mut self.snapshot).unwrap().clear()
+        self.snapshot.clear()
     }
 
     pub fn close(self) {
+        // TODO: Should work by itself
         self.database.release_schema_transaction();
-        drop(self.thing_manager);
-        drop(self.type_manager);
-        Arc::into_inner(self.snapshot).unwrap().close_resources();
+        // drop(self.thing_manager);
+        // drop(self.type_manager);
+        // Arc::into_inner(self.snapshot).unwrap().close_resources();
     }
 }
 

--- a/server/service/grpc/migration/export_service.rs
+++ b/server/service/grpc/migration/export_service.rs
@@ -27,7 +27,6 @@ use crate::service::{
                 encode_attribute_item, encode_checksums_item, encode_entity_item, encode_header_item,
                 encode_relation_item,
             },
-            TransactionHolder,
         },
         response_builders::database::{
             database_export_initial_res_ok, database_export_res_done, database_export_res_part_items,
@@ -113,12 +112,11 @@ impl DatabaseExportService {
     pub(crate) async fn export(mut self) {
         let start = Instant::now();
         event!(Level::INFO, "Exporting '{}' from TypeDB {}.", self.database.name(), self.server_info.version);
-        let Some(holder) = self.open_transaction().await else {
+        let Some(transaction) = self.open_transaction().await else {
             return;
         };
-        let transaction = holder.transaction();
 
-        let schema = unwrap_else_send_error_and_return!(self, get_transaction_schema(transaction));
+        let schema = unwrap_else_send_error_and_return!(self, get_transaction_schema(&transaction));
         unwrap_else_send_error_and_return!(
             self,
             send_response!(self.response_sender, Ok(database_export_initial_res_ok(schema)))
@@ -126,9 +124,9 @@ impl DatabaseExportService {
 
         let mut buffer = Vec::with_capacity(Self::ITEM_BATCH_SIZE);
         unwrap_else_send_error_and_return!(self, self.export_header(&mut buffer).await);
-        unwrap_else_send_error_and_return!(self, self.export_entities(transaction, &mut buffer).await);
-        unwrap_else_send_error_and_return!(self, self.export_relations(transaction, &mut buffer).await);
-        unwrap_else_send_error_and_return!(self, self.export_attributes(transaction, &mut buffer).await);
+        unwrap_else_send_error_and_return!(self, self.export_entities(&transaction, &mut buffer).await);
+        unwrap_else_send_error_and_return!(self, self.export_relations(&transaction, &mut buffer).await);
+        unwrap_else_send_error_and_return!(self, self.export_attributes(&transaction, &mut buffer).await);
         unwrap_else_send_error_and_return!(self, self.export_checksums(&mut buffer).await);
         if !buffer.is_empty() {
             unwrap_else_send_error_and_return!(self, Self::send_items(&self.response_sender, buffer).await);
@@ -266,9 +264,9 @@ impl DatabaseExportService {
         send_response!(response_sender, Ok(database_export_res_part_items(items)))
     }
 
-    async fn open_transaction(&self) -> Option<TransactionHolder> {
+    async fn open_transaction(&self) -> Option<TransactionRead<WALClient>> {
         match TransactionRead::open(self.database.clone(), Self::transaction_options()) {
-            Ok(transaction) => Some(TransactionHolder::new(transaction)),
+            Ok(transaction) => Some(transaction),
             Err(typedb_source) => {
                 Self::send_error(&self.response_sender, DatabaseExportError::TransactionFailed { typedb_source }).await;
                 None

--- a/server/service/grpc/migration/export_service.rs
+++ b/server/service/grpc/migration/export_service.rs
@@ -22,11 +22,8 @@ use crate::service::{
     export_service::{get_transaction_schema, DatabaseExportError},
     grpc::{
         error::{IntoGrpcStatus, IntoProtocolErrorMessage},
-        migration::{
-            item::{
-                encode_attribute_item, encode_checksums_item, encode_entity_item, encode_header_item,
-                encode_relation_item,
-            },
+        migration::item::{
+            encode_attribute_item, encode_checksums_item, encode_entity_item, encode_header_item, encode_relation_item,
         },
         response_builders::database::{
             database_export_initial_res_ok, database_export_res_done, database_export_res_part_items,

--- a/server/service/grpc/migration/mod.rs
+++ b/server/service/grpc/migration/mod.rs
@@ -3,30 +3,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use database::transaction::TransactionRead;
-use storage::durability_client::WALClient;
+use std::fmt;
 
 pub(crate) mod export_service;
 pub(crate) mod import_service;
 pub(crate) mod item;
 
-// TODO: Temp, remove after merges
-struct TransactionHolder(Option<TransactionRead<WALClient>>);
+#[derive(Debug, PartialEq, Eq)]
+struct Checksums {
+    entity_count: i64,
+    attribute_count: i64,
+    relation_count: i64,
+    role_count: i64,
+    ownership_count: i64,
+}
 
-impl TransactionHolder {
-    fn new(transaction: TransactionRead<WALClient>) -> Self {
-        Self(Some(transaction))
-    }
-
-    fn transaction(&self) -> &TransactionRead<WALClient> {
-        self.0.as_ref().expect("Expected transaction")
+impl Checksums {
+    fn new() -> Self {
+        Self::default()
     }
 }
 
-impl Drop for TransactionHolder {
-    fn drop(&mut self) {
-        if let Some(transaction) = self.0.take() {
-            transaction.close();
-        }
+impl Default for Checksums {
+    fn default() -> Self {
+        Self { entity_count: 0, attribute_count: 0, relation_count: 0, role_count: 0, ownership_count: 0 }
+    }
+}
+
+impl fmt::Display for Checksums {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { entity_count, attribute_count, relation_count, role_count, ownership_count } = self;
+        write!(f, "[{entity_count} entities, {attribute_count} attributes, {relation_count} relations, {role_count} roles, {ownership_count} ownerships]")
     }
 }

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -946,7 +946,7 @@ impl TransactionService {
         sender: Sender<StreamQueryResponse>,
     ) -> JoinHandle<()> {
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
-            let snapshot = transaction.snapshot.clone();
+            let snapshot = transaction.snapshot.clone_inner();
             let type_manager = transaction.type_manager.clone();
             let thing_manager = transaction.thing_manager.clone();
             let timeout_at = self.timeout_at;
@@ -1116,7 +1116,7 @@ impl TransactionService {
         let timeout_at = self.timeout_at;
         let interrupt = self.query_interrupt_receiver.clone();
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
-            let snapshot = transaction.snapshot.clone();
+            let snapshot = transaction.snapshot.clone_inner();
             let type_manager = transaction.type_manager.clone();
             let thing_manager = transaction.thing_manager.clone();
             let function_manager = transaction.function_manager.clone();

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -771,7 +771,7 @@ impl TransactionService {
     ) -> ControlFlow<(), ()> {
         // Write query is already executed, but for simplicity, we convert it to something that conform to the same API as the read path
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
-            let snapshot = transaction.snapshot.clone();
+            let snapshot = transaction.snapshot.clone_inner();
             let type_manager = transaction.type_manager.clone();
             let thing_manager = transaction.thing_manager.clone();
             let timeout_at = self.timeout_at;
@@ -977,7 +977,7 @@ impl TransactionService {
         let timeout_at = self.timeout_at;
         let interrupt = self.query_interrupt_receiver.clone();
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
-            let snapshot = transaction.snapshot.clone();
+            let snapshot = transaction.snapshot.clone_inner();
             let type_manager = transaction.type_manager.clone();
             let thing_manager = transaction.thing_manager.clone();
             let function_manager = transaction.function_manager.clone();

--- a/server/state.rs
+++ b/server/state.rs
@@ -15,8 +15,10 @@ use async_trait::async_trait;
 use concept::error::ConceptReadError;
 use concurrency::IntervalRunner;
 use database::{
-    database::DatabaseCreateError, database_manager::DatabaseManager, transaction::TransactionRead, Database,
-    DatabaseDeleteError,
+    database::DatabaseCreateError,
+    database_manager::DatabaseManager,
+    transaction::{TransactionRead, TransactionSchema},
+    Database, DatabaseDeleteError,
 };
 use diagnostics::{diagnostics_manager::DiagnosticsManager, Diagnostics};
 use error::typedb_error;
@@ -265,10 +267,8 @@ impl LocalServerState {
     pub fn get_database_schema<D: DurabilityClient>(database: Arc<Database<D>>) -> Result<String, ServerStateError> {
         let transaction = TransactionRead::open(database, TransactionOptions::default())
             .map_err(|err| ServerStateError::FailedToOpenPrerequisiteTransaction {})?;
-        // TODO: Close transactions on errors?
         let schema = get_transaction_schema(&transaction)
             .map_err(|typedb_source| ServerStateError::DatabaseExport { typedb_source })?;
-        transaction.close();
         Ok(schema)
     }
 
@@ -277,10 +277,8 @@ impl LocalServerState {
     ) -> Result<String, ServerStateError> {
         let transaction = TransactionRead::open(database, TransactionOptions::default())
             .map_err(|err| ServerStateError::FailedToOpenPrerequisiteTransaction {})?;
-        // TODO: Close transactions on errors?
         let type_schema = get_transaction_type_schema(&transaction)
             .map_err(|typedb_source| ServerStateError::DatabaseExport { typedb_source })?;
-        transaction.close();
         Ok(type_schema)
     }
 }

--- a/storage/snapshot/mod.rs
+++ b/storage/snapshot/mod.rs
@@ -5,8 +5,8 @@
  */
 
 pub use snapshot::{
-    CommittableSnapshot, ReadSnapshot, ReadableSnapshot, SchemaSnapshot, SnapshotError, SnapshotGetError,
-    WritableSnapshot, WriteSnapshot,
+    CommittableSnapshot, ReadSnapshot, ReadableSnapshot, SchemaSnapshot, SnapshotDropGuard, SnapshotError,
+    SnapshotGetError, WritableSnapshot, WriteSnapshot,
 };
 
 pub mod buffer;

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -649,6 +649,10 @@ impl<S: ReadableSnapshot> SnapshotDropGuard<S> {
         Self::unwrap_optional(self.inner.as_ref().map(|inner| &**inner))
     }
 
+    pub fn as_mut(&mut self) -> Option<&mut S> {
+        self.inner.as_mut().and_then(Arc::get_mut)
+    }
+
     // ATTENTION: Make sure to drop the clones before Self goes out of scope and drops!
     pub fn clone_inner(&self) -> Arc<S> {
         Self::unwrap_optional(self.inner.as_ref()).clone()
@@ -675,12 +679,6 @@ impl<S: ReadableSnapshot> Deref for SnapshotDropGuard<S> {
 
     fn deref(&self) -> &Self::Target {
         Self::unwrap_optional(self.inner.as_ref().map(|inner| &**inner))
-    }
-}
-
-impl<S: ReadableSnapshot> DerefMut for SnapshotDropGuard<S> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        Self::unwrap_arc_ref_mut(Self::unwrap_optional(self.inner.as_mut()))
     }
 }
 

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -4,7 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{any::type_name, error::Error, fmt, iter::empty, sync::Arc};
+use std::{
+    any::type_name,
+    error::Error,
+    fmt,
+    iter::empty,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use bytes::byte_array::ByteArray;
 use error::typedb_error;
@@ -94,6 +101,8 @@ pub trait ReadableSnapshot {
     ) -> SnapshotRangeIterator;
 
     fn iterator_pool(&self) -> &IteratorPool;
+
+    fn close_resources(&self);
 }
 
 pub trait WritableSnapshot: ReadableSnapshot {
@@ -194,8 +203,6 @@ pub trait WritableSnapshot: ReadableSnapshot {
     fn clear(&mut self) {
         self.operations_mut().clear()
     }
-
-    fn close_resources(&self);
 }
 
 pub trait CommittableSnapshot<D>: WritableSnapshot
@@ -295,6 +302,8 @@ impl<D> ReadableSnapshot for ReadSnapshot<D> {
     fn iterator_pool(&self) -> &IteratorPool {
         &self.iterator_pool
     }
+
+    fn close_resources(&self) {}
 }
 
 pub struct WriteSnapshot<D> {
@@ -422,6 +431,10 @@ impl<D> ReadableSnapshot for WriteSnapshot<D> {
     fn iterator_pool(&self) -> &IteratorPool {
         &self.iterator_pool
     }
+
+    fn close_resources(&self) {
+        self.storage.closed_snapshot_write(self.open_sequence_number());
+    }
 }
 
 impl<D> WritableSnapshot for WriteSnapshot<D> {
@@ -431,10 +444,6 @@ impl<D> WritableSnapshot for WriteSnapshot<D> {
 
     fn operations_mut(&mut self) -> &mut OperationsBuffer {
         &mut self.operations
-    }
-
-    fn close_resources(&self) {
-        self.storage.closed_snapshot_write(self.open_sequence_number());
     }
 }
 
@@ -580,6 +589,10 @@ impl<D> ReadableSnapshot for SchemaSnapshot<D> {
     fn iterator_pool(&self) -> &IteratorPool {
         &self.iterator_pool
     }
+
+    fn close_resources(&self) {
+        self.storage.closed_snapshot_write(self.open_sequence_number());
+    }
 }
 
 impl<D> WritableSnapshot for SchemaSnapshot<D> {
@@ -589,10 +602,6 @@ impl<D> WritableSnapshot for SchemaSnapshot<D> {
 
     fn operations_mut(&mut self) -> &mut OperationsBuffer {
         &mut self.operations
-    }
-
-    fn close_resources(&self) {
-        self.storage.closed_snapshot_write(self.open_sequence_number());
     }
 }
 
@@ -611,6 +620,73 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
 
     fn into_commit_record(self) -> CommitRecord {
         CommitRecord::new(self.operations, self.open_sequence_number, CommitType::Schema)
+    }
+}
+
+#[derive(Debug)]
+pub struct SnapshotDropGuard<S: ReadableSnapshot> {
+    inner: Option<Arc<S>>,
+}
+
+impl<S: ReadableSnapshot> SnapshotDropGuard<S> {
+    pub fn new(inner: S) -> Self {
+        Self::from_arc(Arc::new(inner))
+    }
+
+    pub fn from_arc(inner: Arc<S>) -> Self {
+        Self { inner: Some(inner) }
+    }
+
+    pub fn into_inner(mut self) -> S {
+        Self::unwrap_arc(Self::unwrap_optional(self.inner.take()))
+    }
+
+    pub fn try_into_inner(mut self) -> Option<S> {
+        self.inner.take().map(|inner| Arc::into_inner(inner))?
+    }
+
+    pub fn as_ref(&self) -> &S {
+        Self::unwrap_optional(self.inner.as_ref().map(|inner| &**inner))
+    }
+
+    // ATTENTION: Make sure to drop the clones before Self goes out of scope and drops!
+    pub fn clone_inner(&self) -> Arc<S> {
+        Self::unwrap_optional(self.inner.as_ref()).clone()
+    }
+
+    fn unwrap_arc(arc: Arc<S>) -> S {
+        Arc::into_inner(arc).expect("Arc<WritableSnapshot> expected a unique ownership in a guard")
+    }
+
+    fn unwrap_arc_ref_mut(arc: &mut Arc<S>) -> &mut S {
+        Arc::get_mut(arc).expect("Arc<WritableSnapshot> expected a unique ownership in a guard for mutating")
+    }
+
+    fn unwrap_optional<T>(option: Option<T>) -> T {
+        option.expect("WritableSnapshotDropGuard expected a unique ownership")
+    }
+}
+
+impl<S: ReadableSnapshot> Deref for SnapshotDropGuard<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        Self::unwrap_optional(self.inner.as_ref().map(|inner| &**inner))
+    }
+}
+
+impl<S: ReadableSnapshot> DerefMut for SnapshotDropGuard<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Self::unwrap_arc_ref_mut(Self::unwrap_optional(self.inner.as_mut()))
+    }
+}
+
+impl<S: ReadableSnapshot> Drop for SnapshotDropGuard<S> {
+    fn drop(&mut self) {
+        match self.inner.take() {
+            Some(inner) => Self::unwrap_arc(inner).close_resources(),
+            None => {}
+        }
     }
 }
 

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -642,7 +642,7 @@ impl<S: ReadableSnapshot> SnapshotDropGuard<S> {
     }
 
     pub fn try_into_inner(mut self) -> Option<S> {
-        self.inner.take().map(|inner| Arc::into_inner(inner))?
+        self.inner.take().and_then(Arc::into_inner)
     }
 
     pub fn as_ref(&self) -> &S {
@@ -655,15 +655,18 @@ impl<S: ReadableSnapshot> SnapshotDropGuard<S> {
     }
 
     fn unwrap_arc(arc: Arc<S>) -> S {
-        Arc::into_inner(arc).expect("Arc<WritableSnapshot> expected a unique ownership in a guard")
+        Arc::into_inner(arc)
+            .unwrap_or_else(|| panic!("Arc<{}> expected a unique ownership in a guard", type_name::<Self>()))
     }
 
     fn unwrap_arc_ref_mut(arc: &mut Arc<S>) -> &mut S {
-        Arc::get_mut(arc).expect("Arc<WritableSnapshot> expected a unique ownership in a guard for mutating")
+        Arc::get_mut(arc).unwrap_or_else(|| {
+            panic!("Arc<{}> expected a unique ownership in a guard for mutating", type_name::<Self>())
+        })
     }
 
     fn unwrap_optional<T>(option: Option<T>) -> T {
-        option.expect("WritableSnapshotDropGuard expected a unique ownership")
+        option.unwrap_or_else(|| panic!("{} expected a unique ownership", type_name::<Self>()))
     }
 }
 
@@ -683,9 +686,8 @@ impl<S: ReadableSnapshot> DerefMut for SnapshotDropGuard<S> {
 
 impl<S: ReadableSnapshot> Drop for SnapshotDropGuard<S> {
     fn drop(&mut self) {
-        match self.inner.take() {
-            Some(inner) => Self::unwrap_arc(inner).close_resources(),
-            None => {}
+        if let Some(inner) = self.inner.take() {
+            Self::unwrap_arc(inner).close_resources()
         }
     }
 }

--- a/storage/tests/test_utils_storage/mock_snapshot.rs
+++ b/storage/tests/test_utils_storage/mock_snapshot.rs
@@ -90,4 +90,6 @@ impl ReadableSnapshot for MockSnapshot {
     fn iterator_pool(&self) -> &IteratorPool {
         &self.iterator_pool
     }
+
+    fn close_resources(&self) {}
 }

--- a/system/util.rs
+++ b/system/util.rs
@@ -45,7 +45,7 @@ pub mod transaction_util {
                 transaction_options,
                 profile,
             } = TransactionSchema::open(self.database.clone(), TransactionOptions::default()).unwrap(); // TODO
-            let mut snapshot: SchemaSnapshot<WALClient> = Arc::into_inner(snapshot).unwrap();
+            let mut snapshot: SchemaSnapshot<WALClient> = snapshot.into_inner();
             let result = fn_(&mut snapshot, &type_manager, &thing_manager, &function_manager, &query_manager);
             let tx = TransactionSchema::from_parts(
                 Arc::new(snapshot),
@@ -70,7 +70,7 @@ pub mod transaction_util {
         pub fn write_transaction<T>(
             &self,
             fn_: impl Fn(
-                Arc<WriteSnapshot<WALClient>>,
+                WriteSnapshot<WALClient>,
                 Arc<TypeManager>,
                 Arc<ThingManager>,
                 Arc<FunctionManager>,
@@ -90,7 +90,7 @@ pub mod transaction_util {
                 profile,
             } = TransactionWrite::open(self.database.clone(), TransactionOptions::default()).unwrap();
             let (rows, snapshot) = fn_(
-                snapshot,
+                snapshot.into_inner(),
                 type_manager.clone(),
                 thing_manager.clone(),
                 function_manager.clone(),
@@ -143,7 +143,7 @@ pub mod query_util {
         let prepared_pipeline = tx
             .query_manager
             .prepare_read_pipeline(
-                tx.snapshot.clone(),
+                tx.snapshot.clone_inner(),
                 &tx.type_manager,
                 tx.thing_manager.clone(),
                 &tx.function_manager,

--- a/tests/behaviour/steps/concept/thing/attribute.rs
+++ b/tests/behaviour/steps/concept/thing/attribute.rs
@@ -31,7 +31,7 @@ pub fn attribute_put_instance_with_value_impl(
         let value = value.into_typedb(
             attribute_type.get_value_type_without_source(tx.snapshot.as_ref(), &tx.type_manager).unwrap().unwrap(),
         );
-        tx.thing_manager.create_attribute(tx.snapshot.deref_mut(), attribute_type, value)
+        tx.thing_manager.create_attribute(tx.snapshot.as_mut().unwrap(), attribute_type, value)
     })
 }
 
@@ -153,7 +153,7 @@ async fn delete_attribute(context: &mut Context, var: params::Var) {
         context.attributes[&var.name]
             .clone()
             .unwrap()
-            .delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED)
+            .delete(tx.snapshot.as_mut().unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
             .unwrap()
     })
 }
@@ -190,7 +190,10 @@ async fn delete_attributes_of_type(context: &mut Context, type_label: params::La
             .get_attributes_in(tx.snapshot.as_ref(), attribute_type, StorageCounters::DISABLED)
             .unwrap();
         while let Some(attribute) = attribute_iterator.next() {
-            attribute.unwrap().delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED).unwrap();
+            attribute
+                .unwrap()
+                .delete(tx.snapshot.as_mut().unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
+                .unwrap();
         }
     })
 }

--- a/tests/behaviour/steps/concept/thing/attribute.rs
+++ b/tests/behaviour/steps/concept/thing/attribute.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::{
     error::{ConceptReadError, ConceptWriteError},
@@ -32,7 +31,7 @@ pub fn attribute_put_instance_with_value_impl(
         let value = value.into_typedb(
             attribute_type.get_value_type_without_source(tx.snapshot.as_ref(), &tx.type_manager).unwrap().unwrap(),
         );
-        tx.thing_manager.create_attribute(Arc::get_mut(&mut tx.snapshot).unwrap(), attribute_type, value)
+        tx.thing_manager.create_attribute(tx.snapshot.deref_mut(), attribute_type, value)
     })
 }
 
@@ -154,7 +153,7 @@ async fn delete_attribute(context: &mut Context, var: params::Var) {
         context.attributes[&var.name]
             .clone()
             .unwrap()
-            .delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
+            .delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED)
             .unwrap()
     })
 }
@@ -191,10 +190,7 @@ async fn delete_attributes_of_type(context: &mut Context, type_label: params::La
             .get_attributes_in(tx.snapshot.as_ref(), attribute_type, StorageCounters::DISABLED)
             .unwrap();
         while let Some(attribute) = attribute_iterator.next() {
-            attribute
-                .unwrap()
-                .delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
-                .unwrap();
+            attribute.unwrap().delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED).unwrap();
         }
     })
 }

--- a/tests/behaviour/steps/concept/thing/has.rs
+++ b/tests/behaviour/steps/concept/thing/has.rs
@@ -30,7 +30,7 @@ pub(super) fn object_set_has_impl(
     attribute: &Attribute,
 ) -> Result<(), Box<ConceptWriteError>> {
     with_write_tx!(context, |tx| object.set_has_unordered(
-        tx.snapshot.deref_mut(),
+        tx.snapshot.as_mut().unwrap(),
         &tx.thing_manager,
         attribute,
         StorageCounters::DISABLED
@@ -44,7 +44,7 @@ pub(super) fn object_set_has_ordered_impl(
     attributes: Vec<Attribute>,
 ) -> Result<(), Box<ConceptWriteError>> {
     with_write_tx!(context, |tx| object.set_has_ordered(
-        tx.snapshot.deref_mut(),
+        tx.snapshot.as_mut().unwrap(),
         &tx.thing_manager,
         attribute_type,
         attributes,
@@ -58,7 +58,7 @@ fn object_unset_has_impl(
     key: &Attribute,
 ) -> Result<(), Box<ConceptWriteError>> {
     with_write_tx!(context, |tx| object.unset_has_unordered(
-        tx.snapshot.deref_mut(),
+        tx.snapshot.as_mut().unwrap(),
         &tx.thing_manager,
         key,
         StorageCounters::DISABLED
@@ -76,7 +76,12 @@ fn object_unset_has_ordered_impl(
             .get_attribute_type(tx.snapshot.as_ref(), &attribute_type_label.into_typedb())
             .unwrap()
             .unwrap();
-        object.unset_has_ordered(tx.snapshot.deref_mut(), &tx.thing_manager, attribute_type, StorageCounters::DISABLED)
+        object.unset_has_ordered(
+            tx.snapshot.as_mut().unwrap(),
+            &tx.thing_manager,
+            attribute_type,
+            StorageCounters::DISABLED,
+        )
     })
 }
 

--- a/tests/behaviour/steps/concept/thing/has.rs
+++ b/tests/behaviour/steps/concept/thing/has.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::{
     error::ConceptWriteError,
@@ -31,7 +30,7 @@ pub(super) fn object_set_has_impl(
     attribute: &Attribute,
 ) -> Result<(), Box<ConceptWriteError>> {
     with_write_tx!(context, |tx| object.set_has_unordered(
-        Arc::get_mut(&mut tx.snapshot).unwrap(),
+        tx.snapshot.deref_mut(),
         &tx.thing_manager,
         attribute,
         StorageCounters::DISABLED
@@ -45,7 +44,7 @@ pub(super) fn object_set_has_ordered_impl(
     attributes: Vec<Attribute>,
 ) -> Result<(), Box<ConceptWriteError>> {
     with_write_tx!(context, |tx| object.set_has_ordered(
-        Arc::get_mut(&mut tx.snapshot).unwrap(),
+        tx.snapshot.deref_mut(),
         &tx.thing_manager,
         attribute_type,
         attributes,
@@ -59,7 +58,7 @@ fn object_unset_has_impl(
     key: &Attribute,
 ) -> Result<(), Box<ConceptWriteError>> {
     with_write_tx!(context, |tx| object.unset_has_unordered(
-        Arc::get_mut(&mut tx.snapshot).unwrap(),
+        tx.snapshot.deref_mut(),
         &tx.thing_manager,
         key,
         StorageCounters::DISABLED
@@ -77,12 +76,7 @@ fn object_unset_has_ordered_impl(
             .get_attribute_type(tx.snapshot.as_ref(), &attribute_type_label.into_typedb())
             .unwrap()
             .unwrap();
-        object.unset_has_ordered(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            &tx.thing_manager,
-            attribute_type,
-            StorageCounters::DISABLED,
-        )
+        object.unset_has_ordered(tx.snapshot.deref_mut(), &tx.thing_manager, attribute_type, StorageCounters::DISABLED)
     })
 }
 

--- a/tests/behaviour/steps/concept/thing/object.rs
+++ b/tests/behaviour/steps/concept/thing/object.rs
@@ -36,10 +36,10 @@ fn object_create_instance_impl(
             tx.type_manager.get_object_type(tx.snapshot.as_ref(), &object_type_label.into_typedb()).unwrap().unwrap();
         match object_type {
             ObjectType::Entity(entity_type) => {
-                tx.thing_manager.create_entity(tx.snapshot.deref_mut(), entity_type).map(Object::Entity)
+                tx.thing_manager.create_entity(tx.snapshot.as_mut().unwrap(), entity_type).map(Object::Entity)
             }
             ObjectType::Relation(relation_type) => {
-                tx.thing_manager.create_relation(tx.snapshot.deref_mut(), relation_type).map(Object::Relation)
+                tx.thing_manager.create_relation(tx.snapshot.as_mut().unwrap(), relation_type).map(Object::Relation)
             }
         }
     })
@@ -102,7 +102,7 @@ async fn delete_object(context: &mut Context, object_kind: params::ObjectKind, v
     let object = context.objects[&var.name].as_ref().unwrap().object;
     object_kind.assert(&object.type_());
     with_write_tx!(context, |tx| {
-        object.delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED).unwrap()
+        object.delete(tx.snapshot.as_mut().unwrap(), &tx.thing_manager, StorageCounters::DISABLED).unwrap()
     })
 }
 
@@ -120,7 +120,7 @@ async fn delete_objects_of_type(context: &mut Context, object_kind: params::Obje
                 for entity in entity_iterator {
                     entity
                         .unwrap()
-                        .delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED)
+                        .delete(tx.snapshot.as_mut().unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
                         .unwrap();
                 }
             }
@@ -130,7 +130,7 @@ async fn delete_objects_of_type(context: &mut Context, object_kind: params::Obje
                 for relation in relation_iterator {
                     relation
                         .unwrap()
-                        .delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED)
+                        .delete(tx.snapshot.as_mut().unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
                         .unwrap();
                 }
             }

--- a/tests/behaviour/steps/concept/thing/object.rs
+++ b/tests/behaviour/steps/concept/thing/object.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::{
     error::ConceptWriteError,
@@ -37,12 +36,11 @@ fn object_create_instance_impl(
             tx.type_manager.get_object_type(tx.snapshot.as_ref(), &object_type_label.into_typedb()).unwrap().unwrap();
         match object_type {
             ObjectType::Entity(entity_type) => {
-                tx.thing_manager.create_entity(Arc::get_mut(&mut tx.snapshot).unwrap(), entity_type).map(Object::Entity)
+                tx.thing_manager.create_entity(tx.snapshot.deref_mut(), entity_type).map(Object::Entity)
             }
-            ObjectType::Relation(relation_type) => tx
-                .thing_manager
-                .create_relation(Arc::get_mut(&mut tx.snapshot).unwrap(), relation_type)
-                .map(Object::Relation),
+            ObjectType::Relation(relation_type) => {
+                tx.thing_manager.create_relation(tx.snapshot.deref_mut(), relation_type).map(Object::Relation)
+            }
         }
     })
 }
@@ -104,7 +102,7 @@ async fn delete_object(context: &mut Context, object_kind: params::ObjectKind, v
     let object = context.objects[&var.name].as_ref().unwrap().object;
     object_kind.assert(&object.type_());
     with_write_tx!(context, |tx| {
-        object.delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager, StorageCounters::DISABLED).unwrap()
+        object.delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED).unwrap()
     })
 }
 
@@ -122,7 +120,7 @@ async fn delete_objects_of_type(context: &mut Context, object_kind: params::Obje
                 for entity in entity_iterator {
                     entity
                         .unwrap()
-                        .delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
+                        .delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED)
                         .unwrap();
                 }
             }
@@ -132,7 +130,7 @@ async fn delete_objects_of_type(context: &mut Context, object_kind: params::Obje
                 for relation in relation_iterator {
                     relation
                         .unwrap()
-                        .delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager, StorageCounters::DISABLED)
+                        .delete(tx.snapshot.deref_mut(), &tx.thing_manager, StorageCounters::DISABLED)
                         .unwrap();
                 }
             }

--- a/tests/behaviour/steps/concept/thing/relation.rs
+++ b/tests/behaviour/steps/concept/thing/relation.rs
@@ -42,7 +42,7 @@ async fn relation_add_player_for_role(
         {
             let role_type = relates.role();
             let res = relation.add_player(
-                tx.snapshot.deref_mut(),
+                tx.snapshot.as_mut().unwrap(),
                 &tx.thing_manager,
                 role_type,
                 player,
@@ -75,7 +75,7 @@ async fn relation_set_players_for_role(
             .unwrap()
             .role();
         relation.set_players_ordered(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.thing_manager,
             role_type,
             players,
@@ -105,7 +105,7 @@ async fn relation_remove_player_for_role(
             .role();
 
         let res = relation.remove_player_single(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.thing_manager,
             role_type,
             player,
@@ -135,7 +135,7 @@ async fn relation_remove_count_players_for_role(
             .role();
         relation
             .remove_player_many(
-                tx.snapshot.deref_mut(),
+                tx.snapshot.as_mut().unwrap(),
                 &tx.thing_manager,
                 role_type,
                 player,

--- a/tests/behaviour/steps/concept/thing/relation.rs
+++ b/tests/behaviour/steps/concept/thing/relation.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{slice, sync::Arc};
+use std::{ops::DerefMut, slice, sync::Arc};
 
 use concept::{
     thing::object::{Object, ObjectAPI},
@@ -42,7 +42,7 @@ async fn relation_add_player_for_role(
         {
             let role_type = relates.role();
             let res = relation.add_player(
-                Arc::get_mut(&mut tx.snapshot).unwrap(),
+                tx.snapshot.deref_mut(),
                 &tx.thing_manager,
                 role_type,
                 player,
@@ -75,7 +75,7 @@ async fn relation_set_players_for_role(
             .unwrap()
             .role();
         relation.set_players_ordered(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.thing_manager,
             role_type,
             players,
@@ -105,7 +105,7 @@ async fn relation_remove_player_for_role(
             .role();
 
         let res = relation.remove_player_single(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.thing_manager,
             role_type,
             player,
@@ -135,7 +135,7 @@ async fn relation_remove_count_players_for_role(
             .role();
         relation
             .remove_player_many(
-                Arc::get_mut(&mut tx.snapshot).unwrap(),
+                tx.snapshot.deref_mut(),
                 &tx.thing_manager,
                 role_type,
                 player,

--- a/tests/behaviour/steps/concept/type_/attribute_type.rs
+++ b/tests/behaviour/steps/concept/type_/attribute_type.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::type_::{object_type::ObjectType, TypeAPI};
 use cucumber::gherkin::Step;
@@ -31,7 +30,7 @@ pub async fn attribute_type_set_value_type(
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         let parsed_value_type = value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref());
         let res = attribute_type.set_value_type(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             parsed_value_type,
@@ -50,11 +49,7 @@ pub async fn attribute_type_unset_value_type(
     with_schema_tx!(context, |tx| {
         let attribute_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
-        let res = attribute_type.unset_value_type(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            &tx.type_manager,
-            &tx.thing_manager,
-        );
+        let res = attribute_type.unset_value_type(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }

--- a/tests/behaviour/steps/concept/type_/attribute_type.rs
+++ b/tests/behaviour/steps/concept/type_/attribute_type.rs
@@ -30,7 +30,7 @@ pub async fn attribute_type_set_value_type(
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         let parsed_value_type = value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref());
         let res = attribute_type.set_value_type(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             parsed_value_type,
@@ -49,7 +49,7 @@ pub async fn attribute_type_unset_value_type(
     with_schema_tx!(context, |tx| {
         let attribute_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
-        let res = attribute_type.unset_value_type(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
+        let res = attribute_type.unset_value_type(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }

--- a/tests/behaviour/steps/concept/type_/owns.rs
+++ b/tests/behaviour/steps/concept/type_/owns.rs
@@ -38,7 +38,7 @@ pub async fn set_owns_unordered(
             .unwrap()
             .unwrap();
         let res = object_type.set_owns(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             attr_type,
@@ -66,7 +66,7 @@ pub async fn set_owns_ordered(
             .unwrap()
             .unwrap();
         let res = object_type.set_owns(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             attr_type,
@@ -93,7 +93,7 @@ pub async fn unset_owns(
             .get_attribute_type(tx.snapshot.as_ref(), &attribute_type_label.into_typedb())
             .unwrap()
             .unwrap();
-        let res = object_type.unset_owns(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, attr_type);
+        let res = object_type.unset_owns(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager, attr_type);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -115,7 +115,7 @@ pub async fn get_owns_set_annotation(
         let owns = object_type.get_owns_attribute(tx.snapshot.as_ref(), &tx.type_manager, attr_type).unwrap().unwrap();
         let value_type = attr_type.get_value_type_without_source(tx.snapshot.as_ref(), &tx.type_manager).unwrap();
         let res = owns.set_annotation(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation.into_typedb(value_type).try_into().unwrap(),
@@ -140,7 +140,7 @@ pub async fn get_owns_unset_annotation(
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
         let owns = object_type.get_owns_attribute(tx.snapshot.as_ref(), &tx.type_manager, attr_type).unwrap().unwrap();
         let res = owns.unset_annotation(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation_category.into_typedb(),
@@ -506,8 +506,12 @@ pub async fn get_owns_set_ordering(
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
         let owns = object_type.get_owns_attribute(tx.snapshot.as_ref(), &tx.type_manager, attr_type).unwrap().unwrap();
-        let res =
-            owns.set_ordering(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, ordering.into_typedb());
+        let res = owns.set_ordering(
+            tx.snapshot.as_mut().unwrap(),
+            &tx.type_manager,
+            &tx.thing_manager,
+            ordering.into_typedb(),
+        );
         may_error.check_concept_write_without_read_errors(&res);
     });
 }

--- a/tests/behaviour/steps/concept/type_/owns.rs
+++ b/tests/behaviour/steps/concept/type_/owns.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::type_::{
     annotation, annotation::Annotation, constraint::Constraint, Capability, Ordering, OwnerAPI, TypeAPI,
@@ -39,7 +38,7 @@ pub async fn set_owns_unordered(
             .unwrap()
             .unwrap();
         let res = object_type.set_owns(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             attr_type,
@@ -67,7 +66,7 @@ pub async fn set_owns_ordered(
             .unwrap()
             .unwrap();
         let res = object_type.set_owns(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             attr_type,
@@ -94,12 +93,7 @@ pub async fn unset_owns(
             .get_attribute_type(tx.snapshot.as_ref(), &attribute_type_label.into_typedb())
             .unwrap()
             .unwrap();
-        let res = object_type.unset_owns(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            &tx.type_manager,
-            &tx.thing_manager,
-            attr_type,
-        );
+        let res = object_type.unset_owns(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, attr_type);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -121,7 +115,7 @@ pub async fn get_owns_set_annotation(
         let owns = object_type.get_owns_attribute(tx.snapshot.as_ref(), &tx.type_manager, attr_type).unwrap().unwrap();
         let value_type = attr_type.get_value_type_without_source(tx.snapshot.as_ref(), &tx.type_manager).unwrap();
         let res = owns.set_annotation(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation.into_typedb(value_type).try_into().unwrap(),
@@ -146,7 +140,7 @@ pub async fn get_owns_unset_annotation(
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
         let owns = object_type.get_owns_attribute(tx.snapshot.as_ref(), &tx.type_manager, attr_type).unwrap().unwrap();
         let res = owns.unset_annotation(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation_category.into_typedb(),
@@ -512,12 +506,8 @@ pub async fn get_owns_set_ordering(
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
         let owns = object_type.get_owns_attribute(tx.snapshot.as_ref(), &tx.type_manager, attr_type).unwrap().unwrap();
-        let res = owns.set_ordering(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            &tx.type_manager,
-            &tx.thing_manager,
-            ordering.into_typedb(),
-        );
+        let res =
+            owns.set_ordering(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, ordering.into_typedb());
         may_error.check_concept_write_without_read_errors(&res);
     });
 }

--- a/tests/behaviour/steps/concept/type_/plays.rs
+++ b/tests/behaviour/steps/concept/type_/plays.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::type_::{annotation, constraint::Constraint, plays::PlaysAnnotation, Capability, PlayerAPI, TypeAPI};
 use cucumber::gherkin::Step;
@@ -33,7 +32,7 @@ pub async fn set_plays(
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
         let res = object_type.set_plays(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             role_type,
@@ -56,12 +55,7 @@ pub async fn unset_plays(
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
-        let res = object_type.unset_plays(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            &tx.type_manager,
-            &tx.thing_manager,
-            role_type,
-        );
+        let res = object_type.unset_plays(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, role_type);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -173,7 +167,7 @@ pub async fn get_plays_set_annotation(
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
         let plays = player_type.get_plays_role(tx.snapshot.as_ref(), &tx.type_manager, role_type).unwrap().unwrap();
         let res = plays.set_annotation(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation.into_typedb(None).try_into().unwrap(),
@@ -200,7 +194,7 @@ pub async fn get_plays_unset_annotation(
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
         let plays = player_type.get_plays_role(tx.snapshot.as_ref(), &tx.type_manager, role_type).unwrap().unwrap();
         let res = plays.unset_annotation(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation_category.into_typedb(),

--- a/tests/behaviour/steps/concept/type_/plays.rs
+++ b/tests/behaviour/steps/concept/type_/plays.rs
@@ -32,7 +32,7 @@ pub async fn set_plays(
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
         let res = object_type.set_plays(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             role_type,
@@ -55,7 +55,8 @@ pub async fn unset_plays(
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
-        let res = object_type.unset_plays(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, role_type);
+        let res =
+            object_type.unset_plays(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager, role_type);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -167,7 +168,7 @@ pub async fn get_plays_set_annotation(
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
         let plays = player_type.get_plays_role(tx.snapshot.as_ref(), &tx.type_manager, role_type).unwrap().unwrap();
         let res = plays.set_annotation(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation.into_typedb(None).try_into().unwrap(),
@@ -194,7 +195,7 @@ pub async fn get_plays_unset_annotation(
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
         let plays = player_type.get_plays_role(tx.snapshot.as_ref(), &tx.type_manager, role_type).unwrap().unwrap();
         let res = plays.unset_annotation(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             annotation_category.into_typedb(),

--- a/tests/behaviour/steps/concept/type_/relation_type.rs
+++ b/tests/behaviour/steps/concept/type_/relation_type.rs
@@ -33,7 +33,7 @@ pub async fn relation_type_create_role_unordered(
         let relation_type =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         relation_type.create_relates(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             role_label.into_typedb().name().as_str(),
@@ -56,7 +56,7 @@ pub async fn relation_type_create_role_ordered(
         let relation_type =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         relation_type.create_relates(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             role_label.into_typedb().name().as_str(),
@@ -97,7 +97,7 @@ pub async fn relation_role_set_specialise(
                 .unwrap()
             {
                 let res = relates.set_specialise(
-                    tx.snapshot.deref_mut(),
+                    tx.snapshot.as_mut().unwrap(),
                     &tx.type_manager,
                     &tx.thing_manager,
                     specialised_relates,
@@ -132,7 +132,7 @@ pub async fn relation_role_unset_specialise(
             )
             .unwrap()
             .unwrap();
-        let res = relates.unset_specialise(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
+        let res = relates.unset_specialise(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -423,7 +423,7 @@ pub async fn relation_type_delete_role(
             .unwrap()
             .unwrap()
             .role();
-        let res = role.delete(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
+        let res = role.delete(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -625,7 +625,7 @@ pub async fn relation_role_set_name(
             .unwrap()
             .unwrap()
             .role();
-        let res = role.set_name(tx.snapshot.deref_mut(), &tx.type_manager, to_label.into_typedb().name.as_str());
+        let res = role.set_name(tx.snapshot.as_mut().unwrap(), &tx.type_manager, to_label.into_typedb().name.as_str());
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -653,7 +653,7 @@ pub async fn relation_role_set_annotation(
 
         let parsed_annotation = annotation.into_typedb(None);
         let res = relates.set_annotation(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             parsed_annotation.try_into().unwrap(),
@@ -685,7 +685,7 @@ pub async fn relation_role_unset_annotation(
 
         let parsed_annotation_category = annotation_category.into_typedb();
         let res = relates.unset_annotation(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             parsed_annotation_category,
@@ -984,8 +984,12 @@ pub async fn relation_role_set_ordering(
             .unwrap()
             .unwrap()
             .role();
-        let res =
-            role.set_ordering(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, ordering.into_typedb());
+        let res = role.set_ordering(
+            tx.snapshot.as_mut().unwrap(),
+            &tx.type_manager,
+            &tx.thing_manager,
+            ordering.into_typedb(),
+        );
         may_error.check_concept_write_without_read_errors(&res);
     });
 }

--- a/tests/behaviour/steps/concept/type_/relation_type.rs
+++ b/tests/behaviour/steps/concept/type_/relation_type.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::type_::{
     annotation::Annotation, constraint::Constraint, object_type::ObjectType, Capability, KindAPI, Ordering, TypeAPI,
@@ -34,7 +33,7 @@ pub async fn relation_type_create_role_unordered(
         let relation_type =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         relation_type.create_relates(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             role_label.into_typedb().name().as_str(),
@@ -57,7 +56,7 @@ pub async fn relation_type_create_role_ordered(
         let relation_type =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         relation_type.create_relates(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             role_label.into_typedb().name().as_str(),
@@ -98,7 +97,7 @@ pub async fn relation_role_set_specialise(
                 .unwrap()
             {
                 let res = relates.set_specialise(
-                    Arc::get_mut(&mut tx.snapshot).unwrap(),
+                    tx.snapshot.deref_mut(),
                     &tx.type_manager,
                     &tx.thing_manager,
                     specialised_relates,
@@ -133,8 +132,7 @@ pub async fn relation_role_unset_specialise(
             )
             .unwrap()
             .unwrap();
-        let res =
-            relates.unset_specialise(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
+        let res = relates.unset_specialise(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -425,7 +423,7 @@ pub async fn relation_type_delete_role(
             .unwrap()
             .unwrap()
             .role();
-        let res = role.delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
+        let res = role.delete(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -627,11 +625,7 @@ pub async fn relation_role_set_name(
             .unwrap()
             .unwrap()
             .role();
-        let res = role.set_name(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            &tx.type_manager,
-            to_label.into_typedb().name.as_str(),
-        );
+        let res = role.set_name(tx.snapshot.deref_mut(), &tx.type_manager, to_label.into_typedb().name.as_str());
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -659,7 +653,7 @@ pub async fn relation_role_set_annotation(
 
         let parsed_annotation = annotation.into_typedb(None);
         let res = relates.set_annotation(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             parsed_annotation.try_into().unwrap(),
@@ -691,7 +685,7 @@ pub async fn relation_role_unset_annotation(
 
         let parsed_annotation_category = annotation_category.into_typedb();
         let res = relates.unset_annotation(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             parsed_annotation_category,
@@ -990,12 +984,8 @@ pub async fn relation_role_set_ordering(
             .unwrap()
             .unwrap()
             .role();
-        let res = role.set_ordering(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            &tx.type_manager,
-            &tx.thing_manager,
-            ordering.into_typedb(),
-        );
+        let res =
+            role.set_ordering(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, ordering.into_typedb());
         may_error.check_concept_write_without_read_errors(&res);
     });
 }

--- a/tests/behaviour/steps/concept/type_/struct_definition.rs
+++ b/tests/behaviour/steps/concept/type_/struct_definition.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use cucumber::gherkin::Step;
 use macro_rules_attribute::apply;
@@ -21,10 +20,10 @@ use crate::{
 #[step(expr = "create struct: {type_label}{may_error}")]
 pub async fn struct_create(context: &mut Context, type_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
-        may_error.check_concept_write_without_read_errors(&tx.type_manager.create_struct(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
-            type_label.into_typedb().scoped_name().as_str().to_owned(),
-        ));
+        may_error.check_concept_write_without_read_errors(
+            &tx.type_manager
+                .create_struct(tx.snapshot.deref_mut(), type_label.into_typedb().scoped_name().as_str().to_owned()),
+        );
     });
 }
 
@@ -38,7 +37,7 @@ pub async fn struct_delete(context: &mut Context, type_label: params::Label, may
             .unwrap()
         {
             may_error.check_concept_write_without_read_errors(&tx.type_manager.delete_struct(
-                Arc::get_mut(&mut tx.snapshot).unwrap(),
+                tx.snapshot.deref_mut(),
                 &tx.thing_manager,
                 definition_key,
             ));
@@ -87,7 +86,7 @@ pub async fn struct_create_field_with_value_type(
             .unwrap();
         let parsed_value_type = value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref());
         may_error.check_concept_write_without_read_errors(&tx.type_manager.create_struct_field(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             definition_key.clone(),
             field_label.into_typedb().scoped_name().as_str(),
             parsed_value_type,
@@ -111,7 +110,7 @@ pub async fn struct_delete_field(
             .unwrap()
             .unwrap();
         may_error.check_concept_write_without_read_errors(&tx.type_manager.delete_struct_field(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.thing_manager,
             definition_key.clone(),
             field_label.into_typedb().scoped_name().as_str(),

--- a/tests/behaviour/steps/concept/type_/struct_definition.rs
+++ b/tests/behaviour/steps/concept/type_/struct_definition.rs
@@ -21,8 +21,10 @@ use crate::{
 pub async fn struct_create(context: &mut Context, type_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
         may_error.check_concept_write_without_read_errors(
-            &tx.type_manager
-                .create_struct(tx.snapshot.deref_mut(), type_label.into_typedb().scoped_name().as_str().to_owned()),
+            &tx.type_manager.create_struct(
+                tx.snapshot.as_mut().unwrap(),
+                type_label.into_typedb().scoped_name().as_str().to_owned(),
+            ),
         );
     });
 }
@@ -37,7 +39,7 @@ pub async fn struct_delete(context: &mut Context, type_label: params::Label, may
             .unwrap()
         {
             may_error.check_concept_write_without_read_errors(&tx.type_manager.delete_struct(
-                tx.snapshot.deref_mut(),
+                tx.snapshot.as_mut().unwrap(),
                 &tx.thing_manager,
                 definition_key,
             ));
@@ -86,7 +88,7 @@ pub async fn struct_create_field_with_value_type(
             .unwrap();
         let parsed_value_type = value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref());
         may_error.check_concept_write_without_read_errors(&tx.type_manager.create_struct_field(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             definition_key.clone(),
             field_label.into_typedb().scoped_name().as_str(),
             parsed_value_type,
@@ -110,7 +112,7 @@ pub async fn struct_delete_field(
             .unwrap()
             .unwrap();
         may_error.check_concept_write_without_read_errors(&tx.type_manager.delete_struct_field(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.thing_manager,
             definition_key.clone(),
             field_label.into_typedb().scoped_name().as_str(),

--- a/tests/behaviour/steps/concept/type_/thing_type.rs
+++ b/tests/behaviour/steps/concept/type_/thing_type.rs
@@ -102,17 +102,17 @@ pub async fn type_create(
         match kind.into_typedb() {
             Kind::Entity => {
                 may_error.check_concept_write_without_read_errors(
-                    &tx.type_manager.create_entity_type(tx.snapshot.deref_mut(), &type_label.into_typedb()),
+                    &tx.type_manager.create_entity_type(tx.snapshot.as_mut().unwrap(), &type_label.into_typedb()),
                 );
             }
             Kind::Relation => {
                 may_error.check_concept_write_without_read_errors(
-                    &tx.type_manager.create_relation_type(tx.snapshot.deref_mut(), &type_label.into_typedb()),
+                    &tx.type_manager.create_relation_type(tx.snapshot.as_mut().unwrap(), &type_label.into_typedb()),
                 );
             }
             Kind::Attribute => {
                 may_error.check_concept_write_without_read_errors(
-                    &tx.type_manager.create_attribute_type(tx.snapshot.deref_mut(), &type_label.into_typedb()),
+                    &tx.type_manager.create_attribute_type(tx.snapshot.as_mut().unwrap(), &type_label.into_typedb()),
                 );
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),
@@ -131,7 +131,7 @@ pub async fn type_delete(
     let type_label = type_label.into_typedb();
     with_schema_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
-            let res = type_.delete(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
+            let res = type_.delete(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager);
             may_error.check_concept_write_without_read_errors(&res);
         });
     });
@@ -179,7 +179,7 @@ pub async fn type_set_label(
     with_schema_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
             may_error.check_concept_write_without_read_errors(&type_.set_label(
-                tx.snapshot.deref_mut(),
+                tx.snapshot.as_mut().unwrap(),
                 &tx.type_manager,
                 &to_label.into_typedb(),
             ));
@@ -233,7 +233,7 @@ pub async fn type_set_annotation(
     with_write_tx!(context, |tx| {
         with_type_and_value_type!(tx, kind, type_label, type_, value_type, {
             let res = type_.set_annotation(
-                tx.snapshot.deref_mut(),
+                tx.snapshot.as_mut().unwrap(),
                 &tx.type_manager,
                 &tx.thing_manager,
                 annotation.into_typedb(value_type).try_into().unwrap(),
@@ -256,8 +256,11 @@ pub async fn type_unset_annotation(
     let type_label = type_label.into_typedb();
     with_write_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
-            let res =
-                type_.unset_annotation(tx.snapshot.deref_mut(), &tx.type_manager, annotation_category.into_typedb());
+            let res = type_.unset_annotation(
+                tx.snapshot.as_mut().unwrap(),
+                &tx.type_manager,
+                annotation_category.into_typedb(),
+            );
             may_error.check_concept_write_without_read_errors(&res);
         });
     });
@@ -448,8 +451,12 @@ pub async fn type_set_supertype(
                     .get_attribute_type(tx.snapshot.as_ref(), &supertype_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res =
-                    thistype.set_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, supertype);
+                let res = thistype.set_supertype(
+                    tx.snapshot.as_mut().unwrap(),
+                    &tx.type_manager,
+                    &tx.thing_manager,
+                    supertype,
+                );
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Entity => {
@@ -460,8 +467,12 @@ pub async fn type_set_supertype(
                     .get_entity_type(tx.snapshot.as_ref(), &supertype_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res =
-                    thistype.set_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, supertype);
+                let res = thistype.set_supertype(
+                    tx.snapshot.as_mut().unwrap(),
+                    &tx.type_manager,
+                    &tx.thing_manager,
+                    supertype,
+                );
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Relation => {
@@ -475,8 +486,12 @@ pub async fn type_set_supertype(
                     .get_relation_type(tx.snapshot.as_ref(), &supertype_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res =
-                    thistype.set_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, supertype);
+                let res = thistype.set_supertype(
+                    tx.snapshot.as_mut().unwrap(),
+                    &tx.type_manager,
+                    &tx.thing_manager,
+                    supertype,
+                );
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),
@@ -500,13 +515,13 @@ pub async fn type_unset_supertype(
                     .get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res = thistype.unset_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
+                let res = thistype.unset_supertype(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Entity => {
                 let thistype =
                     tx.type_manager.get_entity_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
-                let res = thistype.unset_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
+                let res = thistype.unset_supertype(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Relation => {
@@ -515,7 +530,7 @@ pub async fn type_unset_supertype(
                     .get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res = thistype.unset_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
+                let res = thistype.unset_supertype(tx.snapshot.as_mut().unwrap(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),

--- a/tests/behaviour/steps/concept/type_/thing_type.rs
+++ b/tests/behaviour/steps/concept/type_/thing_type.rs
@@ -3,8 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use concept::type_::{
     annotation, attribute_type::AttributeTypeAnnotation, constraint::Constraint, entity_type::EntityTypeAnnotation,
@@ -103,20 +102,17 @@ pub async fn type_create(
         match kind.into_typedb() {
             Kind::Entity => {
                 may_error.check_concept_write_without_read_errors(
-                    &tx.type_manager
-                        .create_entity_type(Arc::get_mut(&mut tx.snapshot).unwrap(), &type_label.into_typedb()),
+                    &tx.type_manager.create_entity_type(tx.snapshot.deref_mut(), &type_label.into_typedb()),
                 );
             }
             Kind::Relation => {
                 may_error.check_concept_write_without_read_errors(
-                    &tx.type_manager
-                        .create_relation_type(Arc::get_mut(&mut tx.snapshot).unwrap(), &type_label.into_typedb()),
+                    &tx.type_manager.create_relation_type(tx.snapshot.deref_mut(), &type_label.into_typedb()),
                 );
             }
             Kind::Attribute => {
                 may_error.check_concept_write_without_read_errors(
-                    &tx.type_manager
-                        .create_attribute_type(Arc::get_mut(&mut tx.snapshot).unwrap(), &type_label.into_typedb()),
+                    &tx.type_manager.create_attribute_type(tx.snapshot.deref_mut(), &type_label.into_typedb()),
                 );
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),
@@ -135,7 +131,7 @@ pub async fn type_delete(
     let type_label = type_label.into_typedb();
     with_schema_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
-            let res = type_.delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
+            let res = type_.delete(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
             may_error.check_concept_write_without_read_errors(&res);
         });
     });
@@ -183,7 +179,7 @@ pub async fn type_set_label(
     with_schema_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
             may_error.check_concept_write_without_read_errors(&type_.set_label(
-                Arc::get_mut(&mut tx.snapshot).unwrap(),
+                tx.snapshot.deref_mut(),
                 &tx.type_manager,
                 &to_label.into_typedb(),
             ));
@@ -237,7 +233,7 @@ pub async fn type_set_annotation(
     with_write_tx!(context, |tx| {
         with_type_and_value_type!(tx, kind, type_label, type_, value_type, {
             let res = type_.set_annotation(
-                Arc::get_mut(&mut tx.snapshot).unwrap(),
+                tx.snapshot.deref_mut(),
                 &tx.type_manager,
                 &tx.thing_manager,
                 annotation.into_typedb(value_type).try_into().unwrap(),
@@ -260,11 +256,8 @@ pub async fn type_unset_annotation(
     let type_label = type_label.into_typedb();
     with_write_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
-            let res = type_.unset_annotation(
-                Arc::get_mut(&mut tx.snapshot).unwrap(),
-                &tx.type_manager,
-                annotation_category.into_typedb(),
-            );
+            let res =
+                type_.unset_annotation(tx.snapshot.deref_mut(), &tx.type_manager, annotation_category.into_typedb());
             may_error.check_concept_write_without_read_errors(&res);
         });
     });
@@ -455,12 +448,8 @@ pub async fn type_set_supertype(
                     .get_attribute_type(tx.snapshot.as_ref(), &supertype_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res = thistype.set_supertype(
-                    Arc::get_mut(&mut tx.snapshot).unwrap(),
-                    &tx.type_manager,
-                    &tx.thing_manager,
-                    supertype,
-                );
+                let res =
+                    thistype.set_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, supertype);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Entity => {
@@ -471,12 +460,8 @@ pub async fn type_set_supertype(
                     .get_entity_type(tx.snapshot.as_ref(), &supertype_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res = thistype.set_supertype(
-                    Arc::get_mut(&mut tx.snapshot).unwrap(),
-                    &tx.type_manager,
-                    &tx.thing_manager,
-                    supertype,
-                );
+                let res =
+                    thistype.set_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, supertype);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Relation => {
@@ -490,12 +475,8 @@ pub async fn type_set_supertype(
                     .get_relation_type(tx.snapshot.as_ref(), &supertype_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res = thistype.set_supertype(
-                    Arc::get_mut(&mut tx.snapshot).unwrap(),
-                    &tx.type_manager,
-                    &tx.thing_manager,
-                    supertype,
-                );
+                let res =
+                    thistype.set_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager, supertype);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),
@@ -519,21 +500,13 @@ pub async fn type_unset_supertype(
                     .get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res = thistype.unset_supertype(
-                    Arc::get_mut(&mut tx.snapshot).unwrap(),
-                    &tx.type_manager,
-                    &tx.thing_manager,
-                );
+                let res = thistype.unset_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Entity => {
                 let thistype =
                     tx.type_manager.get_entity_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
-                let res = thistype.unset_supertype(
-                    Arc::get_mut(&mut tx.snapshot).unwrap(),
-                    &tx.type_manager,
-                    &tx.thing_manager,
-                );
+                let res = thistype.unset_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Relation => {
@@ -542,11 +515,7 @@ pub async fn type_unset_supertype(
                     .get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb())
                     .unwrap()
                     .unwrap();
-                let res = thistype.unset_supertype(
-                    Arc::get_mut(&mut tx.snapshot).unwrap(),
-                    &tx.type_manager,
-                    &tx.thing_manager,
-                );
+                let res = thistype.unset_supertype(tx.snapshot.deref_mut(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use cucumber::gherkin::Step;
 use database::{
@@ -207,7 +207,7 @@ fn execute_schema_transaction(
     transaction
         .query_manager
         .execute_schema(
-            Arc::get_mut(&mut transaction.snapshot).ok_or("Failed to get mutable reference").unwrap(),
+            transaction.snapshot.deref_mut(),
             &transaction.type_manager,
             &transaction.thing_manager,
             &transaction.function_manager,

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -207,7 +207,7 @@ fn execute_schema_transaction(
     transaction
         .query_manager
         .execute_schema(
-            transaction.snapshot.deref_mut(),
+            transaction.snapshot.as_mut().unwrap(),
             &transaction.type_manager,
             &transaction.thing_manager,
             &transaction.function_manager,

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, iter, str::FromStr, sync::Arc};
+use std::{collections::HashMap, iter, ops::DerefMut, str::FromStr, sync::Arc};
 
 use answer::{variable_value::VariableValue, Thing};
 use compiler::VariablePosition;
@@ -29,6 +29,7 @@ use macro_rules_attribute::apply;
 use params;
 use query::error::QueryError;
 use resource::profile::StorageCounters;
+use storage::snapshot::SnapshotDropGuard;
 use test_utils::assert_matches;
 
 use crate::{
@@ -71,7 +72,7 @@ fn execute_read_query(
 ) -> Result<QueryAnswer, Box<QueryError>> {
     with_read_tx!(context, |tx| {
         let pipeline = tx.query_manager.prepare_read_pipeline(
-            tx.snapshot.clone(),
+            tx.snapshot.clone_inner(),
             &tx.type_manager,
             tx.thing_manager.clone(),
             &tx.function_manager,
@@ -130,10 +131,8 @@ fn execute_write_query(
                                            query_manager,
                                            _db,
                                            _opts| {
-        let snapshot = Arc::into_inner(snapshot).unwrap();
-
         let pipeline_result = query_manager.prepare_write_pipeline(
-            snapshot,
+            snapshot.into_inner(),
             &type_manager,
             thing_manager.clone(),
             &function_manager,
@@ -142,7 +141,9 @@ fn execute_write_query(
         );
 
         match pipeline_result {
-            Err((snapshot, error)) => (Err(BehaviourTestExecutionError::Query(*error)), Arc::new(snapshot)),
+            Err((snapshot, error)) => {
+                (Err(BehaviourTestExecutionError::Query(*error)), SnapshotDropGuard::new(snapshot))
+            }
             Ok(pipeline) => {
                 if pipeline.has_fetch() {
                     match pipeline.into_documents_iterator(ExecutionInterrupt::new_uninterruptible()) {
@@ -156,14 +157,14 @@ fn execute_write_query(
                                     }))
                                 }
                             },
-                            snapshot,
+                            SnapshotDropGuard::from_arc(snapshot),
                         ),
                         Err((err, ExecutionContext { snapshot, .. })) => (
                             Err(BehaviourTestExecutionError::Query(QueryError::WritePipelineExecution {
                                 source_query: source_query.to_string(),
                                 typedb_source: err,
                             })),
-                            snapshot,
+                            SnapshotDropGuard::from_arc(snapshot),
                         ),
                     }
                 } else {
@@ -174,14 +175,14 @@ fn execute_write_query(
                             match result_as_batch {
                                 Ok(batch) => (
                                     Ok(QueryAnswer::ConceptRows(row_batch_result_to_answer(batch, named_outputs))),
-                                    snapshot,
+                                    SnapshotDropGuard::from_arc(snapshot),
                                 ),
                                 Err(typedb_source) => (
                                     Err(BehaviourTestExecutionError::Query(QueryError::WritePipelineExecution {
                                         source_query: source_query.to_string(),
                                         typedb_source,
                                     })),
-                                    snapshot,
+                                    SnapshotDropGuard::from_arc(snapshot),
                                 ),
                             }
                         }
@@ -190,7 +191,7 @@ fn execute_write_query(
                                 source_query: source_query.to_string(),
                                 typedb_source: err,
                             })),
-                            snapshot,
+                            SnapshotDropGuard::from_arc(snapshot),
                         ),
                     }
                 }
@@ -218,7 +219,7 @@ async fn typeql_schema_query(context: &mut Context, may_error: params::TypeQLMay
 
     with_schema_tx!(context, |tx| {
         let result = tx.query_manager.execute_schema(
-            Arc::get_mut(&mut tx.snapshot).unwrap(),
+            tx.snapshot.deref_mut(),
             &tx.type_manager,
             &tx.thing_manager,
             &tx.function_manager,

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -219,7 +219,7 @@ async fn typeql_schema_query(context: &mut Context, may_error: params::TypeQLMay
 
     with_schema_tx!(context, |tx| {
         let result = tx.query_manager.execute_schema(
-            tx.snapshot.deref_mut(),
+            tx.snapshot.as_mut().unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             &tx.function_manager,

--- a/tests/benchmarks/iam/bench_iam.rs
+++ b/tests/benchmarks/iam/bench_iam.rs
@@ -39,7 +39,7 @@ fn load_schema_tql(database: Arc<Database<WALClient>>, schema_tql: &Path) {
         transaction_options,
         profile,
     } = tx;
-    let mut inner_snapshot = Arc::into_inner(snapshot).unwrap();
+    let mut inner_snapshot = snapshot.into_inner();
     query_manager
         .execute_schema(
             &mut inner_snapshot,
@@ -82,7 +82,7 @@ fn load_data_tql(database: Arc<Database<WALClient>>, data_tql: &Path) {
     } = tx;
     let write_pipeline = query_manager
         .prepare_write_pipeline(
-            Arc::into_inner(snapshot).unwrap(),
+            snapshot.into_inner(),
             &type_manager,
             thing_manager.clone(),
             &function_manager,
@@ -130,7 +130,7 @@ fn run_query(database: Arc<Database<WALClient>>, query_str: &str) -> Batch {
     let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
     let pipeline = query_manager
         .prepare_read_pipeline(
-            snapshot.clone(),
+            snapshot.clone_inner(),
             type_manager,
             thing_manager.clone(),
             function_manager,

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -61,15 +61,7 @@ impl UserManager {
         let create_result = self
             .transaction_util
             .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _dbb, _tx_opts| {
-                user_repository::create(
-                    Arc::into_inner(snapshot).unwrap(),
-                    &type_mgr,
-                    thing_mgr.clone(),
-                    &fn_mgr,
-                    &query_mgr,
-                    user,
-                    credential,
-                )
+                user_repository::create(snapshot, &type_mgr, thing_mgr.clone(), &fn_mgr, &query_mgr, user, credential)
             })
             .1;
         match create_result {
@@ -89,7 +81,7 @@ impl UserManager {
             .transaction_util
             .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
                 user_repository::update(
-                    Arc::into_inner(snapshot).unwrap(),
+                    snapshot,
                     &type_mgr,
                     thing_mgr.clone(),
                     &fn_mgr,
@@ -127,14 +119,7 @@ impl UserManager {
         let delete_result = self
             .transaction_util
             .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
-                user_repository::delete(
-                    Arc::into_inner(snapshot).unwrap(),
-                    &type_mgr,
-                    thing_mgr.clone(),
-                    &fn_mgr,
-                    &query_mgr,
-                    username,
-                )
+                user_repository::delete(snapshot, &type_mgr, thing_mgr.clone(), &fn_mgr, &query_mgr, username)
             })
             .1;
         match delete_result {


### PR DESCRIPTION
## Usage and product changes
We refactor `Transaction` structs to allow them to release the resources properly when they go out of scope even without explicitly calling for `close()` or `commit()`. A `close()` equivalent will be called instead.

This allows opening transactions without their explicit closure, which is frequently helpful in methods with many potential early returns on question mark operations `?`.

## Motivation
When transactions were dropped without being closed or committed, they could potentially leave acquired resources without proper cleanup. This especially mattered for write and schema transactions as they require counters and locks releases in the end of their lifetime, which could easily be missed in code like
```
let tx = TransactionSchema::new(...);
func()?;
tx.close();
``` 

## Implementation
We cannot implement `Drop` on transaction structs directly as:
* we need to be able to unpack them, moving the elements out of structs (`let TransactionSchema {snapshot, ....) = tx;` or `let snapshot = tx.snapshot;`)
* following from the previous point, it's not completely safe to release resources on every transaction deconstruction as it plays a role of a wrapper more than an owner of resources, as we frequently unpack and repack its members

Instead, we make sure that every member of these structs is dropped correctly only when they are no longer needed. To achieve this, two drop guards were introduced. These guards allow moving the members without calling for destructors, making sure to leave the resources allocated and safe while the transactions around them are created and destroyed.

### DatabaseDropGuard 
A guard for the `Arc<Database>` member of transactions. Owns the arc and allows accessing it without additional calls through `impl Deref`. When dropped, calls an optional function on this database for additional resource cleanup. E.g.,:
* `DatabaseDropGuard::new_with_fn(database, Database::release_write_transaction)` for write transactions
* `DatabaseDropGuard::new_with_fn(database, Database::release_schema_transaction)` for schema transactions

### SnapshotDropGuard
A guard for the `Arc<Snapshot>` member of transactions. To make this work with all transactions, the resource cleanup method was moved from `trait WritableSnapshot` to `trait ReadableSnapshot` (with an empty impl for read snapshots).

This guard owns the arc and allows access in various ways through an intermediate API, generalizing the potential `Arc::into_inner().unwrap()` calls and others. On drop, it makes sure to call for the snapshot's resource cleanup.